### PR TITLE
Adding configurable sms length calculations

### DIFF
--- a/src/de/ub0r/android/websms/DefaultSMSLengthCalculator.java
+++ b/src/de/ub0r/android/websms/DefaultSMSLengthCalculator.java
@@ -1,0 +1,44 @@
+package de.ub0r.android.websms;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+import de.ub0r.android.lib.apis.TelephonyWrapper;
+import de.ub0r.android.websms.connector.common.SMSLengthCalculator;
+
+/**
+ * 
+ * A SMSLengthCalculator that just delegates to
+ * TelephonyWrapper.getInstance().calculateLength
+ * 
+ * @author Fintan Fairmichael
+ * 
+ */
+public class DefaultSMSLengthCalculator implements SMSLengthCalculator {
+	private static final long serialVersionUID = -1021281060248896432L;
+
+	@Override
+	public void writeToParcel(final Parcel dest, final int flags) {
+	}
+
+	@Override
+	public int describeContents() {
+		return 0;
+	}
+
+	@Override
+	public int[] calculateLength(final String messageBody,
+			final boolean use7bitOnly) {
+		return TelephonyWrapper.getInstance().calculateLength(messageBody,
+				use7bitOnly);
+	}
+
+	public static final Parcelable.Creator<DefaultSMSLengthCalculator> CREATOR = new Parcelable.Creator<DefaultSMSLengthCalculator>() {
+		public DefaultSMSLengthCalculator createFromParcel(final Parcel in) {
+			return new DefaultSMSLengthCalculator();
+		}
+
+		public DefaultSMSLengthCalculator[] newArray(final int size) {
+			return new DefaultSMSLengthCalculator[size];
+		}
+	};
+}

--- a/src/de/ub0r/android/websms/WebSMS.java
+++ b/src/de/ub0r/android/websms/WebSMS.java
@@ -85,11 +85,11 @@ import de.ub0r.android.lib.Changelog;
 import de.ub0r.android.lib.DonationHelper;
 import de.ub0r.android.lib.Market;
 import de.ub0r.android.lib.apis.ContactsWrapper;
-import de.ub0r.android.lib.apis.TelephonyWrapper;
 import de.ub0r.android.websms.connector.common.Connector;
 import de.ub0r.android.websms.connector.common.ConnectorCommand;
 import de.ub0r.android.websms.connector.common.ConnectorSpec;
 import de.ub0r.android.websms.connector.common.Log;
+import de.ub0r.android.websms.connector.common.SMSLengthCalculator;
 import de.ub0r.android.websms.connector.common.Utils;
 import de.ub0r.android.websms.connector.common.ConnectorSpec.SubConnectorSpec;
 
@@ -134,9 +134,8 @@ public class WebSMS extends FragmentActivity implements OnClickListener,
 		AD_KEYWORDS.add("amazon");
 	}
 
-	/** {@link TelephonyWrapper}. */
-	private static final TelephonyWrapper TWRAPPER = TelephonyWrapper
-			.getInstance();
+	/** Default sms length calculator */
+	private static final SMSLengthCalculator SMS_LENGTH_CALCULATOR = new DefaultSMSLengthCalculator();
 
 	/** Static reference to running Activity. */
 	private static WebSMS me;
@@ -341,8 +340,12 @@ public class WebSMS extends FragmentActivity implements OnClickListener,
 				len += sig.length();
 				WebSMS.this.tvPaste.setVisibility(View.GONE);
 				if (len > TEXT_LABLE_MIN_LEN) {
-					int[] l = TWRAPPER.calculateLength(s.toString() + sig,
-							false);
+					SMSLengthCalculator calc = prefsConnectorSpec
+							.getSMSLengthCalculator();
+					if (calc == null) {
+						calc = SMS_LENGTH_CALCULATOR;
+					}
+					int[] l = calc.calculateLength(s.toString() + sig, false);
 					WebSMS.this.etTextLabel.setText(l[0] + "/" + l[2]);
 					WebSMS.this.etTextLabel.setVisibility(View.VISIBLE);
 				} else {


### PR DESCRIPTION
Added DefaultSMSLengthCalculator to delegate to TelephonyWrapper. Using connector-specified SMSLengthCalculator with fallback to the default.

(As discussed in http://code.google.com/p/websmsdroid/issues/detail?id=574 )
