### PR TITLE
connector switch as action

### DIFF
--- a/res/menu-large/menu.xml
+++ b/res/menu-large/menu.xml
@@ -22,6 +22,11 @@
         android:showAsAction="always|withText"
         android:title="@string/update_"/>
     <item
+        android:id="@+id/item_connector"
+        android:icon="@android:drawable/ic_menu_share"
+        android:showAsAction="ifRoom|withText"
+        android:title="@string/change_connector_"/>
+    <item
         android:id="@+id/item_send"
         android:icon="@drawable/ic_menu_send"
         android:showAsAction="ifRoom|withText"
@@ -31,11 +36,6 @@
         android:icon="@android:drawable/ic_menu_save"
         android:showAsAction="never"
         android:title="@string/save_draft_"/>
-    <item
-        android:id="@+id/item_connector"
-        android:icon="@android:drawable/ic_menu_share"
-        android:showAsAction="never"
-        android:title="@string/change_connector_"/>
     <item
         android:id="@+id/item_savechars"
         android:icon="@android:drawable/ic_menu_sort_alphabetically"

--- a/res/menu-xlarge/menu.xml
+++ b/res/menu-xlarge/menu.xml
@@ -22,6 +22,11 @@
         android:showAsAction="always|withText"
         android:title="@string/update_"/>
     <item
+        android:id="@+id/item_connector"
+        android:icon="@android:drawable/ic_menu_share"
+        android:showAsAction="ifRoom|withText"
+        android:title="@string/change_connector_"/>
+    <item
         android:id="@+id/item_send"
         android:icon="@drawable/ic_menu_send"
         android:showAsAction="ifRoom|withText"
@@ -31,11 +36,6 @@
         android:icon="@android:drawable/ic_menu_save"
         android:showAsAction="never"
         android:title="@string/save_draft_"/>
-    <item
-        android:id="@+id/item_connector"
-        android:icon="@android:drawable/ic_menu_share"
-        android:showAsAction="never"
-        android:title="@string/change_connector_"/>
     <item
         android:id="@+id/item_savechars"
         android:icon="@android:drawable/ic_menu_sort_alphabetically"

--- a/res/menu/menu.xml
+++ b/res/menu/menu.xml
@@ -22,6 +22,11 @@
         android:showAsAction="always|never"
         android:title="@string/update_"/>
     <item
+        android:id="@+id/item_connector"
+        android:icon="@android:drawable/ic_menu_share"
+        android:showAsAction="ifRoom|never"
+        android:title="@string/change_connector_"/>
+    <item
         android:id="@+id/item_send"
         android:icon="@drawable/ic_menu_send"
         android:showAsAction="ifRoom|never"
@@ -31,11 +36,6 @@
         android:icon="@android:drawable/ic_menu_save"
         android:showAsAction="never"
         android:title="@string/save_draft_"/>
-    <item
-        android:id="@+id/item_connector"
-        android:icon="@android:drawable/ic_menu_share"
-        android:showAsAction="never"
-        android:title="@string/change_connector_"/>
     <item
         android:id="@+id/item_savechars"
         android:icon="@android:drawable/ic_menu_sort_alphabetically"


### PR DESCRIPTION
c34dd802ca  show connector switch on action bar if multiple connectors

Imho, if a user has several connectors then he most likely means to use them and (until we have connector selection rules) needs to switch between them often. (I do anyway.) So it would be useful to have the switch option on the action bar (if there are multiple connectors).
