### PR TITLE
fix italian strings.xml

### DIFF
--- a/res/values-it/strings.xml
+++ b/res/values-it/strings.xml
@@ -27,7 +27,6 @@
   <string name="faq_hint" formatted="false" username="carloraudino@fedoraproject.org" orig="Some tips and tricks, how to set up this app.">Alcuni trucchi e suggerimenti su come impostare l\'applicazione.</string>
   <string name="feedback_" formatted="false" username="antoniogallo@alice.de" orig="Feedback">Feedback</string>
   <string name="feedback_hint" formatted="false" username="carloraudino@fedoraproject.org" orig="Report bugs, request features ...">Segnala bug, richiedi funzioni ...</string>
-\nRicevi notifiche su aggiornamenti ecc.</string>
   <string name="author_" formatted="false" username="antoniogallo@alice.de" orig="Author:">Autore:</string>
   <string name="author_connectors_" formatted="false" username="carloraudino@fedoraproject.org" orig="Author of Connectors:">Sviluppatore dei Connector:</string>
   <string name="change_connector_" formatted="false" username="antoniogallo@alice.de" orig="Change provider">Cambia provider</string>


### PR DESCRIPTION
the commit 933ebc8504dd154f2b973060033b6fd36dae4bb8 removed the
"twitter_hint" everywhere, but in values-it/strings.xml this string was
multiline, so that the xml is invalid now which prevents the build
